### PR TITLE
Feat: monsters targetSeek property

### DIFF
--- a/data/monster/monsters/minions/mage_minion.xml
+++ b/data/monster/monsters/minions/mage_minion.xml
@@ -4,7 +4,8 @@
 	<look type="214" corpse="6055" />
 	<targetchange interval="4000" chance="20" />
 	<targetseeks>
-		<targetseek cid="bazir" priority="5" />
+		<targetseek cid="wolf" priority="5" />
+		<targetseek cid="rabbit" priority="5" />
 	</targetseeks>
 	<flags>
 		<flag summonable="0" />

--- a/data/monster/monsters/minions/mage_minion.xml
+++ b/data/monster/monsters/minions/mage_minion.xml
@@ -3,6 +3,9 @@
 	<health now="100" max="100" />
 	<look type="214" corpse="6055" />
 	<targetchange interval="4000" chance="20" />
+	<targetseeks>
+		<targetseek cid="bazir" priority="5" />
+	</targetseeks>
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/monster/monsters/minions/siege_minion.xml
+++ b/data/monster/monsters/minions/siege_minion.xml
@@ -3,6 +3,10 @@
 	<health now="250" max="250" />
 	<look type="50" corpse="5996" />
 	<targetchange interval="4000" chance="20" />
+	<targetseeks>
+		<targetseek cid="wolf" priority="5" />
+		<targetseek cid="rabbit" priority="5" />
+	</targetseeks>
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/monster/monsters/minions/super_minion.xml
+++ b/data/monster/monsters/minions/super_minion.xml
@@ -4,7 +4,8 @@
 	<look type="935" head="94" body="1" legs="80" feet="94" corpse="27730" />
 	<targetchange interval="4000" chance="20" />
 	<targetseeks>
-		<targetseek cid="bazir" priority="5" />
+		<targetseek cid="wolf" priority="5" />
+		<targetseek cid="rabbit" priority="5" />
 	</targetseeks>
 	<flags>
 		<flag summonable="0" />

--- a/data/monster/monsters/minions/super_minion.xml
+++ b/data/monster/monsters/minions/super_minion.xml
@@ -3,6 +3,9 @@
 	<health now="600" max="600" />
 	<look type="935" head="94" body="1" legs="80" feet="94" corpse="27730" />
 	<targetchange interval="4000" chance="20" />
+	<targetseeks>
+		<targetseek cid="bazir" priority="5" />
+	</targetseeks>
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/monster/monsters/minions/warrior_minion.xml
+++ b/data/monster/monsters/minions/warrior_minion.xml
@@ -3,6 +3,10 @@
 	<health now="200" max="200" />
 	<look type="215" corpse="6058" />
 	<targetchange interval="4000" chance="20" />
+	<targetseeks>
+		<targetseek cid="wolf" priority="5" />
+		<targetseek cid="rabbit" priority="5" />
+	</targetseeks>
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -406,3 +406,13 @@ registerMonsterType.defenses = function(mtype, mask)
 		end
 	end
 end
+registerMonsterType.targetseeks = function (mtype, mask)
+	if type(mask.targetseeks) == "table" then
+		for _, target_seek in pairs(mask) do
+			local creature = Creature(target_seek.cid)
+			if creature then
+				mtype:addTargetSeek(creature, target_seek.priority or 1)
+			end
+		end
+	end
+end

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -10,6 +10,7 @@
 #include "game.h"
 #include "spectators.h"
 #include "weapons.h"
+#include "monster.h"
 
 extern Game g_game;
 extern Weapons* g_weapons;
@@ -379,9 +380,10 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
 		} else if (attacker->getMonster()) {
+			const Monster* attackerMonster = attacker->getMonster();
 			const Creature* targetMaster = target->getMaster();
 
-			if (!targetMaster || !targetMaster->getPlayer()) {
+			if ((!targetMaster || !targetMaster->getPlayer()) && !attackerMonster->isSeekTarget(target)) {
 				const Creature* attackerMaster = attacker->getMaster();
 
 				if (!attackerMaster || !attackerMaster->getPlayer()) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14358,6 +14358,36 @@ int LuaScriptInterface::luaMonsterTypeAddAttack(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaMonsterTypeAddTargetSeek(lua_State* L)
+{
+	std::cout << "Adding a new target to SEEK!!!" << std::endl;
+	//monsterType::addTargetSeek(creature, priority)
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		std::cout << "Monster Type found!!! " << monsterType->name << std::endl;
+		Creature* creature = getUserdata<Creature>(L, 2);
+		uint32_t priority = getNumber<uint32_t>(L, 3);
+
+		if (creature) {
+			std::cout << "Creature found!!! " << creature->getName() << std::endl;
+
+
+			targetSeekBlock_t targetSeek;
+			targetSeek.cid = creature->getID();
+			targetSeek.priority = priority;
+			monsterType->info.targetSeeks.push_back(targetSeek);
+			pushBoolean(L, true);
+		} else {
+			lua_pushnil(L);
+		}
+
+	} else {
+		lua_pushnil(L);
+	}
+
+	return 1;
+}
+
 int LuaScriptInterface::luaMonsterTypeGetDefenseList(lua_State* L)
 {
 	// monsterType:getDefenseList()

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1324,6 +1324,8 @@ private:
 	static int luaMonsterTypeGetAttackList(lua_State* L);
 	static int luaMonsterTypeAddAttack(lua_State* L);
 
+	static int luaMonsterTypeAddTargetSeek(lua_State* L);
+
 	static int luaMonsterTypeGetDefenseList(lua_State* L);
 	static int luaMonsterTypeAddDefense(lua_State* L);
 

--- a/src/map.h
+++ b/src/map.h
@@ -21,7 +21,7 @@ struct AStarNode
 	uint16_t x, y;
 };
 
-static constexpr int32_t MAX_NODES = 512;
+static constexpr int32_t MAX_NODES = 1024;
 
 static constexpr int32_t MAP_NORMALWALKCOST = 10;
 static constexpr int32_t MAP_DIAGONALWALKCOST = 25;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -387,7 +387,7 @@ void Monster::updateTargetList()
 
 		for (auto target : mType->info.targetSeeks) {
 			auto creature = g_game.getCreatureByName(target.cid);
-			if (creature) {
+			if (creature && !creature->isDead()) {
 				onCreatureFound(creature, true);
 			}
 		}
@@ -471,6 +471,10 @@ bool Monster::isFriend(const Creature* creature) const
 
 bool Monster::isSeekTarget(const Creature* creature) const
 {
+	if (creature == nullptr || creature->isDead()) {
+		return false;
+	}
+
 	auto lowerCasedName = boost::algorithm::to_lower_copy(creature->getName());
 	if (mType->info.targetSeeks.size() > 0) {
 		for (auto target : mType->info.targetSeeks) {
@@ -506,8 +510,6 @@ bool Monster::isOpponent(const Creature* creature) const
 
 void Monster::onCreatureLeave(Creature* creature)
 {
-	// std::cout << "onCreatureLeave - " << creature->getName() << std::endl;
-
 	if (getMaster() == creature) {
 		// Take random steps and only use defense abilities (e.g. heal) until its master comes back
 		isMasterInRange = false;
@@ -663,7 +665,7 @@ BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32
 bool Monster::isTarget(const Creature* creature) const
 {
 	if ((creature->isRemoved() || !creature->isAttackable() || creature->getZone() == ZONE_PROTECTION ||
-	    !canSeeCreature(creature) && !isSeekTarget(creature))) {
+	    !canSeeCreature(creature)) && !isSeekTarget(creature)) {
 		return false;
 	}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -332,7 +332,7 @@ void Monster::removeFriend(Creature* creature)
 void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
 {
 	assert(creature != this);
-	if (std::find(targetList.begin(), targetList.end(), creature) == targetList.end()) {
+	if (std::find(targetList.begin(), targetList.end(), creature) == targetList.end() || isSeekTarget(creature)) {
 		creature->incrementReferenceCounter();
 		if (pushFront) {
 			targetList.push_front(creature);
@@ -381,6 +381,17 @@ void Monster::updateTargetList()
 	for (Creature* spectator : spectators) {
 		onCreatureFound(spectator);
 	}
+
+	if (mType->info.targetSeeks.size() > 0) {
+		std::list<Creature*> seeks;
+
+		for (auto target : mType->info.targetSeeks) {
+			auto creature = g_game.getCreatureByName(target.cid);
+			if (creature) {
+				onCreatureFound(creature, true);
+			}
+		}
+	}
 }
 
 void Monster::clearTargetList()
@@ -405,7 +416,7 @@ void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/)
 		return;
 	}
 
-	if (!canSee(creature->getPosition())) {
+	if (!canSee(creature->getPosition()) && !isSeekTarget(creature)) {
 		return;
 	}
 
@@ -451,8 +462,23 @@ bool Monster::isFriend(const Creature* creature) const
 		if (tmpPlayer && (tmpPlayer == getMaster() || masterPlayer->isPartner(tmpPlayer))) {
 			return true;
 		}
-	} else if (creature->getMonster() && !creature->isSummon()) {
+	} else if (creature->getMonster() && !creature->isSummon() && !isSeekTarget(creature)) {
 		return true;
+	}
+
+	return false;
+}
+
+bool Monster::isSeekTarget(const Creature* creature) const
+{
+	auto lowerCasedName = boost::algorithm::to_lower_copy(creature->getName());
+	if (mType->info.targetSeeks.size() > 0) {
+		for (auto target : mType->info.targetSeeks) {
+			auto lowerCasedTarget = boost::algorithm::to_lower_copy(target.cid);
+			if (lowerCasedName.compare(lowerCasedTarget) == 0) {
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -460,6 +486,10 @@ bool Monster::isFriend(const Creature* creature) const
 
 bool Monster::isOpponent(const Creature* creature) const
 {
+	if (isSeekTarget(creature)) {
+		return true;
+	}
+
 	if (isSummon() && getMaster()->getPlayer()) {
 		if (creature != getMaster()) {
 			return true;
@@ -632,8 +662,8 @@ BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32
 
 bool Monster::isTarget(const Creature* creature) const
 {
-	if (creature->isRemoved() || !creature->isAttackable() || creature->getZone() == ZONE_PROTECTION ||
-	    !canSeeCreature(creature)) {
+	if ((creature->isRemoved() || !creature->isAttackable() || creature->getZone() == ZONE_PROTECTION ||
+	    !canSeeCreature(creature) && !isSeekTarget(creature))) {
 		return false;
 	}
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -113,6 +113,7 @@ public:
 	const CreatureHashSet& getFriendList() const { return friendList; }
 
 	bool isTarget(const Creature* creature) const;
+	bool isSeekTarget(const Creature* creature) const;
 	bool isFleeing() const
 	{
 		return !isSummon() && getHealth() <= mType->info.runAwayHealth && challengeFocusDuration <= 0;

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1361,6 +1361,28 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 		}
 	}
 
+	if ((node = monsterNode.child("targetseeks"))) {
+		for (auto targetSeekNode : node.children()) {
+			uint32_t priority = 1;
+
+			if ((attr = targetSeekNode.attribute("priority"))) {
+				priority = pugi::cast<uint32_t>(attr.value());
+			}
+
+			if ((attr = targetSeekNode.attribute("cid"))) {
+				std::string cid = attr.as_string();
+
+				targetSeekBlock_t targetSeek;
+				targetSeek.cid = cid;
+				targetSeek.priority = priority;
+
+				mType->info.targetSeeks.emplace_back(targetSeek);
+			} else {
+				std::cout << "[Warning - Monsters::loadMonster] Missing target to seek cid(name). " << file << std::endl;
+			}
+		}
+	}
+
 	if ((node = monsterNode.child("script"))) {
 		for (auto eventNode : node.children()) {
 			if ((attr = eventNode.attribute("name"))) {
@@ -1377,6 +1399,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 	mType->info.defenseSpells.shrink_to_fit();
 	mType->info.voiceVector.shrink_to_fit();
 	mType->info.scripts.shrink_to_fit();
+	mType->info.targetSeeks.shrink_to_fit();
 	return mType;
 }
 

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -56,6 +56,12 @@ struct summonBlock_t
 	bool force = false;
 };
 
+struct targetSeekBlock_t
+{
+	std::string cid;
+	uint32_t priority = 1;
+};
+
 class BaseSpell;
 struct spellBlock_t
 {
@@ -107,6 +113,7 @@ class MonsterType
 		std::vector<spellBlock_t> attackSpells;
 		std::vector<spellBlock_t> defenseSpells;
 		std::vector<summonBlock_t> summons;
+		std::vector<targetSeekBlock_t> targetSeeks;
 
 		Skulls_t skull = SKULL_NONE;
 		Outfit_t outfit = {};


### PR DESCRIPTION
## targetSeek property 

This PR is introducing the changes needed to implement the `targetSeek` property correctly. With this prop, we can:
- Make a monster attack another monster
- Make a monster follow the target longer than it can see